### PR TITLE
Retaining original replay file when selecting it from list. 

### DIFF
--- a/Bird's Replay Manager/Form1.cs
+++ b/Bird's Replay Manager/Form1.cs
@@ -76,6 +76,13 @@ namespace Bird_s_Replay_Manager
             if (itemSelected == true) //Check if an item is selected
             {
                 replayFilePath = dolphinPath + "/ReplayData/" + listBox1.SelectedItem.ToString(); //Set replayFilePath to the selected replay file
+                // Filename should be in format "collect.vff DD-MM-YYYY HH-MM-SS" if it hasn't been used before
+                // If selected a backup file, will be "collect Backup <stuff>"
+                // Below comments for future timestamp saving if needed
+                // Honestly, probably don't even need the backup stuff if you're retaining the original file but that's neither here nor there
+
+                // string originalFilename = listBox1.SelectedItem.ToString();
+                // string filenameInfo = originalFilename.Substring(originalFilename.IndexOf(' ') + 1); // Will grab file info after collect.vff 
 
                 while (File.Exists(dolphinPath + "/User/Wii/title/00010000/52534245/data/collect.vff") && itemSelected == true) //While there is a collect.vff file in the user folder and a replay is selected
                 {

--- a/Bird's Replay Manager/Form1.cs
+++ b/Bird's Replay Manager/Form1.cs
@@ -104,6 +104,7 @@ namespace Bird_s_Replay_Manager
                 if (!File.Exists(dolphinPath + "/User/Wii/title/00010000/52534245/data/collect.vff") && itemSelected == true) //If there is no replay save file in the user folder
                 {
                     System.IO.File.Move(replayFilePath, dolphinPath + "/User/Wii/title/00010000/52534245/data/collect.vff"); //Move the selected replay to the user folder and rename it
+                    System.IO.File.Copy(dolphinPath + "/User/Wii/title/00010000/52534245/data/collect.vff", replayFilePath); //Make a copy of moved file at original location to preserve folder state
                     listBox1.Items.Remove(listBox1.SelectedItem); //Remove the currently selected replay
                     listBox1.ClearSelected(); //Clear which replay was selected
                     refreshListboxes(); //Refresh items in listboxes

--- a/Bird's Replay Manager/Form1.cs
+++ b/Bird's Replay Manager/Form1.cs
@@ -43,6 +43,10 @@ namespace Bird_s_Replay_Manager
                 {
                     Directory.CreateDirectory(dolphinPath + "/ReplayData"); //Create ReplayData folder
                 }
+                if(!Directory.Exists(dolphinPath + "/ReplayData/Backups"))
+                {
+                    Directory.CreateDirectory(dolphinPath + "/ReplayData/Backups");
+                }
                 refreshListboxes(); //Refresh items in listboxes
             }
         }
@@ -69,6 +73,10 @@ namespace Bird_s_Replay_Manager
             {
                 refreshListboxes(); //Refresh items in listboxes
             }
+            if (!Directory.Exists(dolphinPath + "/ReplayData/Backups") && cancelled == false) { //If ReplayData/Backups doesn't exist
+                Directory.CreateDirectory(dolphinPath + "/ReplayData/Backups");
+                refreshListboxes();
+            }
         }
 
         private void useReplayButton_Click(object sender, EventArgs e)
@@ -86,16 +94,16 @@ namespace Bird_s_Replay_Manager
 
                 while (File.Exists(dolphinPath + "/User/Wii/title/00010000/52534245/data/collect.vff") && itemSelected == true) //While there is a collect.vff file in the user folder and a replay is selected
                 {
-                    string path = dolphinPath + "/ReplayData/collect Backup 1.vff"; //Set path to a default backup in the ReplayData folder
+                    string path = dolphinPath + "/ReplayData/Backups/collect Backup 1.vff"; //Set path to a default backup in the ReplayData folder
 
                     for (int i = 1; File.Exists(path); ++i) //Add 1 to file name until no matching file name is found
                     {
-                        if (!File.Exists(dolphinPath + "/ReplayData/collect Backup 1.vff")) //If default replay backup doesnt't exist
-                            path = dolphinPath + "/ReplayData/collect Backup 1.vff"; //Set path to default replay backup
+                        if (!File.Exists(dolphinPath + "/ReplayData/Backups/collect Backup 1.vff")) //If default replay backup doesnt't exist
+                            path = dolphinPath + "/ReplayData/Backup/collect Backup 1.vff"; //Set path to default replay backup
 
                         else if (File.Exists(path)) //But if a replay backup does exist
                         {
-                            path = dolphinPath + "/ReplayData/collect Backup " + i + ".vff"; //Set path to backup + an open number
+                            path = dolphinPath + "/ReplayData/Backups/collect Backup " + i + ".vff"; //Set path to backup + an open number
                         }
                     }
 


### PR DESCRIPTION
### Changes
When moving a replay file from the ReplayData folder to the Wii folder location, the original file would get removed from the ReplayData location. It's pretty annoying if you're trying to retain an archive of replays with the datetime string preserved in the filename, as switching them (e.g. while getting clips or doing replay review) will make it hard to track what replay was when. 

It's a single line file copy that copies the moved file from the Wii location, back to ReplayData with the original filename. I've done some basic testing to make sure the replays aren't messed up by watching a few after copying them back, not sure if something more robust is required for testing.

### Future Ideas:
This change seems sufficient for now, but I don't think the whole file backup thing is required anymore. However, to make certain that no replay files are lost when moving things around, I propose modifying the existing functionality a little and having a /ReplayData/Backups folder where the existing collect.vff is moved into when switching out replays. This will ensure no replays are lost, but also avoid backups clogging up the ReplayData folder, and by extension, the Replay Manager list of replays. I'll probably go about doing this later in the week when i have some free time.

Not 100% sure this is the best way to solve the problem, but seems like the easiest way while improving tool function. Feel free to reach out to me on discord at Baker#4484 if you wanna discuss anything about this or propose an alternative